### PR TITLE
fix: Prevent getPosts() from returning non-MDX files

### DIFF
--- a/public/rss.xml
+++ b/public/rss.xml
@@ -9,7 +9,7 @@
             <link>https://blog.maximeheckel.com</link>
         </image>
         <generator>RSS for Node</generator>
-        <lastBuildDate>Fri, 03 Jul 2026 16:59:26 GMT</lastBuildDate>
+        <lastBuildDate>Wed, 08 Jul 2026 20:06:36 GMT</lastBuildDate>
         <atom:link href="https://blog.maximeheckel.com/rss.xml" rel="self" type="application/rss+xml"/>
         <language><![CDATA[en]]></language>
         <item>
@@ -483,20 +483,6 @@
             <guid isPermaLink="false">https://blog.maximeheckel.com/posts/running-golang-tests-with-jest-b5d8f3d43a7</guid>
             <dc:creator><![CDATA[Maxime heckel]]></dc:creator>
             <pubDate>Wed, 10 Jan 2018 17:00:17 GMT</pubDate>
-        </item>
-        <item>
-            <title><![CDATA[No title]]></title>
-            <link>https://blog.maximeheckel.com/posts/glossary.json</link>
-            <guid isPermaLink="false">https://blog.maximeheckel.com/posts/glossary.json</guid>
-            <dc:creator><![CDATA[Maxime heckel]]></dc:creator>
-            <pubDate>Invalid Date</pubDate>
-        </item>
-        <item>
-            <title><![CDATA[No title]]></title>
-            <link>https://blog.maximeheckel.com/posts/LICENSE</link>
-            <guid isPermaLink="false">https://blog.maximeheckel.com/posts/LICENSE</guid>
-            <dc:creator><![CDATA[Maxime heckel]]></dc:creator>
-            <pubDate>Invalid Date</pubDate>
         </item>
     </channel>
 </rss>

--- a/scripts/generate-rss.js
+++ b/scripts/generate-rss.js
@@ -21,6 +21,10 @@ const __dirname = path.dirname(__filename);
       .filter((name) => name !== 'img');
 
     const posts = files.reduce((allPosts, postSlug) => {
+      if (!postSlug.endsWith('.mdx')) {
+        return allPosts;
+      }
+
       const source = fs.readFileSync(
         path.join(root, 'content', postSlug),
         'utf8'


### PR DESCRIPTION
This prevents LICENSE and glossary.json from appearing at the end of the RSS feed. Both of these are invalid entries and appear in a reader as empty posts with the title "No title". 
